### PR TITLE
Previous non-binary link was dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There are two ways you can add yourself.
 1. [Open an Issue] listing your details
 2. [Edit the Speaker List HTML online] and add yourself
 
-[non-binary]: http://nonbinary.org/
+[non-binary]: https://en.wikipedia.org/wiki/Genderqueer
 [Code of Conduct]: https://github.com/enbytech/enbytech.github.io/blob/master/CODE_OF_CONDUCT.md
 [Open an Issue]: https://github.com/enbytech/enbytech.github.io/issues/new
 [Edit the Speaker List HTML online]: https://github.com/enbytech/enbytech.github.io/blob/master/index.html


### PR DESCRIPTION
Sadly nonbinary.org appears to be down. The Wikipedia article for Genderqueer has non-binary bolded and in the first sentence so I believe it is a good replacement.